### PR TITLE
fix: Fix comment viewset logics

### DIFF
--- a/algo_sports/blogs/serializers.py
+++ b/algo_sports/blogs/serializers.py
@@ -52,6 +52,7 @@ class ReCommentSerializer(serializers.ModelSerializer):
 class CommentSerializer(serializers.ModelSerializer):
     user = UsernameSerializer(read_only=True)
     post = serializers.PrimaryKeyRelatedField(read_only=True)
+    recomments = ReCommentSerializer(source="get_childs", many=True, required=False)
 
     class Meta:
         model = Comment

--- a/algo_sports/blogs/tests/test_comment_viewset.py
+++ b/algo_sports/blogs/tests/test_comment_viewset.py
@@ -1,15 +1,32 @@
 import pytest
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory
 
-from algo_sports.blogs.tests.factories import CommentFactory
+from algo_sports.blogs.tests.factories import CommentFactory, PostFactory
+from algo_sports.blogs.views import CommentViewSet
 from algo_sports.users.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
 class TestCommentViewSet:
+    def test_get_querset(self):
+        view = CommentViewSet()
+
+        user = UserFactory()
+
+        rf = APIRequestFactory()
+        request = rf.get("/fake_url/")
+        request.user = user
+
+        view.request = request
+
+        post = PostFactory()
+        parent_size = 10
+        CommentFactory.create_batch(parent_size, post_id=post)
+        assert view.get_queryset().count() == parent_size
+
     def test_add_recomment(self):
         client = APIClient()
 
@@ -29,7 +46,7 @@ class TestCommentViewSet:
         url = reverse("api:comment-add-recomment", kwargs={"pk": recomment_pk})
         response = client.post(url, data={"content": "RereComment is not allowed!"})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_comment_delete(self):
         client = APIClient()

--- a/algo_sports/blogs/views.py
+++ b/algo_sports/blogs/views.py
@@ -139,6 +139,10 @@ class CommentViewSet(
         "add_recomment": ReCommentSerializer,
     }
 
+    def get_queryset(self):
+        queryset = self.queryset.filter(parent_id__isnull=True)
+        return queryset
+
     def get_serializer_class(self):
         serializer = self.action_serializer_classes.get(self.action)
         if serializer:


### PR DESCRIPTION
get_queryset(self)

parent_id가 없는 comment만 반환하도록 수정

---

CommentSerializer에 recomments 추가

프론트에 전달할 때 Comment와 Recomment를 함께 전달한다.